### PR TITLE
Install Java through sdkman

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Google Drive client for OS X now is only suggested via the official download page.
 - Tomcat to v9.0.20.
 - Install ZSH only when isn't already installed.
+- Java installed through sdkman.
 
 ## Fixed
 - GIT properties now are configured ok. #66

--- a/common.sh
+++ b/common.sh
@@ -56,9 +56,6 @@ fi
 # shellcheck source=modules/google-drive.sh
 . modules/google-drive.sh
 
-# shellcheck source=modules/java.sh
-. modules/java.sh
-
 # shellcheck source=modules/gimp.sh
 . modules/gimp.sh
 
@@ -75,6 +72,10 @@ fi
 # sdkman at the end because SDKMAN_DIR environment variable must be at the end to work.
 # shellcheck source=modules/sdkman.sh
 . modules/sdkman.sh
+
+# Remember that java.sh requires sdkman.sh.
+# shellcheck source=modules/java.sh
+. modules/java.sh
 
 # Remember that maven.sh requires sdkman.sh.
 # shellcheck source=modules/maven.sh

--- a/modules/java.sh
+++ b/modules/java.sh
@@ -3,15 +3,14 @@
 
 enterDirOrExit "${CURRENT_DIR}"
 
-if grep "JAVA_HOME" ~/.zshrc; then
-   logAlreadyInstalled "Java"
-   logProgramVersion "Java" "$(java version)"
-else
-    logInfo "Download latest Java7 from: http://www.oracle.com/technetwork/java/javase/downloads/java-archive-downloads-javase7-521261.html"
-    logInfo "Download latest Java8 from: http://www.oracle.com/technetwork/java/javase/downloads/java-archive-javase8-2177648.html"
-    logInfo "Remember to update JAVA_HOME environment variable after installing Java"
+if ! command -v java >/dev/null; then
+    preInstallationLog "Java"
 
-    log "Setting up Java environment variables..."
-    addToShell "export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.7.0_79.jdk/Contents/Home"
-    addToShell "export PATH=\$JAVA_HOME/bin:\$PATH"
+    sdk install java
+
+    postInstallationLog "Java"
+else
+    logAlreadyInstalled "Java"
 fi
+
+logProgramVersion "Java" "$(java -version)"


### PR DESCRIPTION
## Changes
- Move Java after sdkman
- Install Java through sdkman
- Stop adding custom env vars for JAVA_HOME

## Why do we need this?
To stop doing it manually and with potential errors due to custom paths