### PR TITLE
Always install ruby even if it's already installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.4.0
+## Changed
+- Always install latest Ruby even if it's already installed.
+
 # v2.3.0
 ## Added
 - Finder relaunch automatically.

--- a/modules/ruby.sh
+++ b/modules/ruby.sh
@@ -16,17 +16,10 @@ else
     logAlreadyInstalled "RVM"
 fi
 
-
-if ! command -v ruby >/dev/null; then
-    preInstallationLog "Ruby"
-
-    rvm install ruby
-
-    postInstallationLog "Ruby"
-else
-    logAlreadyInstalled "Ruby"
-fi
-
-
 logProgramVersion "RVM" "$(rvm version)"
+
+
+# Always install latest ruby available even if it's already installed.
+rvm install ruby
+
 logProgramVersion "Ruby" "$(ruby -version)"


### PR DESCRIPTION
## Changes
Run `rvm install ruby` even if it's already installed.

## Why do we need this?
Because OS X already has ruby but it can be an old version.