### PR TITLE
Add Audacity download link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Added
 - GIT diff-so-fancy to use `git diff` the right way. #70
 - `~/Coding/tools` directory to PATH.
+- Link to Audacity download on OS X.
 
 ## Changed
 - Always install latest Ruby even if it's already installed.

--- a/common.sh
+++ b/common.sh
@@ -84,3 +84,7 @@ logSummary "Added ~/Coding/tools to PATH"
 # Remember that maven.sh requires sdkman.sh.
 # shellcheck source=modules/maven.sh
 . modules/maven.sh
+
+if isOsx "$PLATFORM"; then
+    logSummary "Remember to download Audacity for audio edition from: https://www.audacityteam.org/download/mac/"
+fi


### PR DESCRIPTION
## Changes
Just that. It's for Ubuntu so at least I want the download link.

## Why do we need this?
Kind of consistency across platforms