### PR TITLE
Fix typo in SSH installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.4.2
+## Fixed
+- SSH installation failure because of a typo.
+
 # v2.4.1
 ## Fixed
 - Duplicated logs.

--- a/modules/oh-my-zsh/oh-my-zsh.sh
+++ b/modules/oh-my-zsh/oh-my-zsh.sh
@@ -14,7 +14,7 @@ if ! command -v zsh >/dev/null; then
 
     postInstallationLog "ZSH"
 else
-    chsh -s "$(which zsh)"
+    chsh -s "$(command -v zsh)"
     logAlreadyInstalled "ZSH"
 fi
 

--- a/modules/ssh.sh
+++ b/modules/ssh.sh
@@ -9,7 +9,7 @@ logWarn "Generating a new SSH Key for $USER_EMAIL" &&
 ssh-keygen -t rsa -C "$USER_EMAIL" &&
 
 # Start the ssh-agent in the background
-eval "$(ssh-agent-s)" &&
+eval "$(ssh-agent -s)" &&
 
 # Finally add the new key.
 ssh-add ~/.ssh/id_rsa &&


### PR DESCRIPTION
## Changes
Call `ssh-agent -s` instead of `ssh-agent-s` which is causing the issue #87.

## Why do we need this?
To solve issue #87 and successfully finish setup of the SSH module.