### PR TITLE
Fix GIT credentials setup in OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
   - shellcheck modules/mixxx.sh
   - shellcheck modules/nodejs.sh
   - shellcheck modules/oh-my-zsh/oh-my-zsh.sh
-  - shellcheck modules/ssh.sh
+  - shellcheck modules/ssh/ssh.sh
   - shellcheck modules/sublime-text.sh
   - shellcheck modules/tomcat.sh
   - shellcheck Ubuntu/core.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v2.4.2
 ## Fixed
-- SSH installation failure because of a typo.
+- SSH installation failure because of a typo. #87
+- SSH setup on OS X now will store credentials on keychain. #73
 
 # v2.4.1
 ## Fixed

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ EFU (Easy-Fast-Upgradable): The SH script you need to finish your Ubuntu/MacOS X
 
 ## Project status
 [![GitHub version](https://badge.fury.io/gh/barriosnahuel%2Fefu.svg)](http://github.com/barriosnahuel/efu/releases)
+[![Semver](http://img.shields.io/badge/SemVer-v2.0.0-green.png)](http://semver.org/spec/v2.0.0.html)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/011979e103b14efbb00573f2fc47795d)](https://www.codacy.com/app/barrios.nahuel/efu?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=barriosnahuel/efu&amp;utm_campaign=Badge_Grade)
-[![Semver](http://img.shields.io/SemVer/2.0.0.png)](http://semver.org/spec/v2.0.0.html)
 [![stable](https://img.shields.io/badge/stability-stable-green.svg)](https://nodejs.org/api/documentation.html#documentation_stability_index)
 [![Build Status](https://travis-ci.org/barriosnahuel/efu.svg?branch=master)](https://travis-ci.org/barriosnahuel/efu)
 

--- a/common.sh
+++ b/common.sh
@@ -34,7 +34,7 @@ logSummary "Added ~/Coding/tools to PATH"
 . modules/git.sh
 
 # shellcheck source=modules/ssh.sh
-. modules/ssh.sh
+. modules/ssh/ssh.sh
 
 # Remember that oh-my-zsh.sh requires Homebrew.sh.
 # shellcheck source=modules/oh-my-zsh.sh

--- a/common.sh
+++ b/common.sh
@@ -33,7 +33,7 @@ logSummary "Added ~/Coding/tools to PATH"
 # shellcheck source=modules/git.sh
 . modules/git.sh
 
-# shellcheck source=modules/ssh.sh
+# shellcheck source=modules/ssh/ssh.sh
 . modules/ssh/ssh.sh
 
 # Remember that oh-my-zsh.sh requires Homebrew.sh.

--- a/modules/ssh/config
+++ b/modules/ssh/config
@@ -1,0 +1,4 @@
+Host *
+  AddKeysToAgent yes
+  UseKeychain yes
+  IdentityFile ~/.ssh/id_rsa

--- a/modules/ssh/ssh.sh
+++ b/modules/ssh/ssh.sh
@@ -9,14 +9,21 @@ logWarn "Generating a new SSH Key for $USER_EMAIL" &&
 ssh-keygen -t rsa -C "$USER_EMAIL" &&
 
 # Start the ssh-agent in the background
-eval "$(ssh-agent -s)" &&
+eval "$(ssh-agent-s)" &&
 
 # Finally add the new key.
-ssh-add ~/.ssh/id_rsa &&
+if isOsx "$PLATFORM" ; then
 
-logSummary "SSH key added for $USER_EMAIL"
+    cp config ~/.ssh/ &&
+    ssh-add -K ~/.ssh/id_rsa &&
 
-if isUbuntu "$PLATFORM" ; then
+    # shellcheck disable=SC2002
+    cat ~/.ssh/id_rsa.pub | pbcopy
+    logSummary "SSH Key copied to clipboard. If not, just run: 'cat ~/.ssh/id_rsa.pub | pbcopy'"
+
+else
+
+    ssh-add ~/.ssh/id_rsa &&
 
     if ! command -v xclip >/dev/null; then
         preInstallationLog "xclip"
@@ -28,9 +35,5 @@ if isUbuntu "$PLATFORM" ; then
 
     xclip -sel clip < ~/.ssh/id_rsa.pub
     logSummary "SSH Key copied to clipboard. If don't, just run: 'xclip -sel clip < ~/.ssh/id_rsa.pub'"
-else
-
-    # shellcheck disable=SC2002
-    cat ~/.ssh/id_rsa.pub | pbcopy
-    logSummary "SSH Key copied to clipboard. If not, just run: 'cat ~/.ssh/id_rsa.pub | pbcopy'"
 fi
+logSummary "SSH key added for $USER_EMAIL"

--- a/modules/ssh/ssh.sh
+++ b/modules/ssh/ssh.sh
@@ -15,7 +15,7 @@ eval "$(ssh-agent-s)" &&
 if isOsx "$PLATFORM" ; then
 
     cp config ~/.ssh/ &&
-    ssh-add -K ~/.ssh/id_rsa &&
+    ssh-add -K ~/.ssh/id_rsa
 
     # shellcheck disable=SC2002
     cat ~/.ssh/id_rsa.pub | pbcopy


### PR DESCRIPTION
## Changes
Honor setup from [GitHub help](https://help.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent).

Fixes #73 

## Why do we need this?
To prevent GIT to ask for credentials each time.