### PR TITLE
Add curl in README to get latest release from CMD

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Tip: For CMD lovers...
 curl -OJ https://codeload.github.com/barriosnahuel/efu/zip/v2.4.2 \
 && unzip efu-2.4.2.zip \
 && rm -rf efu-2.4.2.zip \
-&& cd efu-2.4.2
+&& cd efu-2.4.2 \
+&& sh install.sh ubuntu
 ```
 
 ## What does EFU do for me?

--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ So you will have 3 tabs:
 - One for `efu.log` output. ⇐ *Full script output.*
 - One for `summary.efu.log` output. ⇐ *Most cases this will be enough.*
 
+Tip: For CMD lovers...
+
+```
+curl -OJ https://codeload.github.com/barriosnahuel/efu/zip/v2.4.2 \
+&& unzip efu-2.4.2.zip \
+&& rm -rf efu-2.4.2.zip \
+&& cd efu-2.4.2
+```
+
 ## What does EFU do for me?
 With a little of your interaction, EFU will:
 - Create a directories tree under ~/Coding for coders.

--- a/modules/oh-my-zsh/oh-my-zsh.sh
+++ b/modules/oh-my-zsh/oh-my-zsh.sh
@@ -29,7 +29,7 @@ sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/mas
 postInstallationLog "Oh-My-ZSH"
 
 addToShell "# DEFAULT_USER env var is used to prevent showing the user@machine in some ZSH themes. i.e.: agnoster"
-addToShell "export DEFAULT_USER=$MACHINE_USER"
+addToShell "export DEFAULT_USER=$USER"
 
 logInfo "Adding custom GIT info to the terminal"
 cp modules/oh-my-zsh/custom-git.zsh ~/.oh-my-zsh/custom/ &&

--- a/properties.sh
+++ b/properties.sh
@@ -2,11 +2,6 @@
 # Created by Nahuel Barrios on 24/3/16.
 
 #########################################
-#### Used for some Oh-My-ZSH themes  ####
-#########################################
-MACHINE_USER="nbarrios"
-
-#########################################
 #### Will be used for in GIT module. ####
 #########################################
 USER_FULL_NAME="Nahuel Barrios"


### PR DESCRIPTION
## Changes
- Add a simple curl to download latest release and install it (default: `ubuntu`).
- Stop forcing the user to declare its user name in `properties.sh` ==> less setup! :)

## Why do we need this?
It's an enhancement for CMD lovers