### PR TITLE
Use wget in README setup in favor of Ubuntu clean installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ So you will have 3 tabs:
 Tip: For CMD lovers...
 
 ```
-curl -OJ https://codeload.github.com/barriosnahuel/efu/zip/v2.4.2 \
+wget --content-disposition https://codeload.github.com/barriosnahuel/efu/zip/v2.4.2 \
 && unzip efu-2.4.2.zip \
 && rm -rf efu-2.4.2.zip \
 && cd efu-2.4.2 \

--- a/Ubuntu/core.sh
+++ b/Ubuntu/core.sh
@@ -24,8 +24,8 @@ logInfo "Instaling latest Rhythmbox and its plugins..."
 sudo apt-get -fy install rhythmbox rhythmbox-plugin-rhythmweb rhythmbox-plugin-equalizer rhythmbox-plugin-opencontainingfolder rhythmbox-plugin-llyrics
 
 
-preInstallationLog "Subdownloader, GMountISO, Freemind (a mind maps editor), Sound Converter, Steam client (will update on first run) and PlayOnLinux"
-sudo apt-get -fy install subdownloader gmountiso freemind soundconverter steam playonlinux
+preInstallationLog "Curl, Subdownloader, GMountISO, Freemind (a mind maps editor), Sound Converter, Steam client (will update on first run) and PlayOnLinux"
+sudo apt-get -fy install curl subdownloader gmountiso freemind soundconverter steam playonlinux
 postInstallationLog "Subdownloader, GMountISO, Freemind (a mind maps editor), Sound Converter, Steam client (will update on first run) and PlayOnLinux"
 
 


### PR DESCRIPTION
## Changes
- Replace curl with wget in README.
- Add curl in core Ubuntu/Lubuntu module.

## Why do we need this?
Because clean Ubuntu installations doesn't have curl