### PR TITLE
Stop asking user confirmation before apt-get autoremove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v2.6.1
 ## Fixed
 - Stop trying to run script for Ubuntu 15.04.
+- Stop asking user confirmation before running `apt-get autoremove`.
 
 ## Removed
 - Legacy Ubuntu scripts.

--- a/Ubuntu/core.sh
+++ b/Ubuntu/core.sh
@@ -31,7 +31,7 @@ postInstallationLog "Subdownloader, GMountISO, Freemind (a mind maps editor), So
 
 logInfo "Cleaning up..." &&
 sudo apt-get -f install &&
-sudo apt-get autoremove &&
+sudo apt-get -y autoremove &&
 sudo apt-get -y autoclean &&
 sudo apt-get -y clean
 


### PR DESCRIPTION
## Changes
Add `-y` to `apt-get autoremove` command.

## Why do we need this?
To run in non-interactive mode.